### PR TITLE
feat: update for netbox-mcp-server v1.0.0 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Read about this agent in the related [blog post from NetBox Labs](https://netbox
 
 1. Python 3.10 or higher
 2. NetBox instance with API access
-3. [NetBox MCP server](https://github.com/netboxlabs/netbox-mcp-server) installed
+3. [NetBox MCP server](https://github.com/netboxlabs/netbox-mcp-server) v1.0.0+ installed
 4. [uv](https://github.com/astral-sh/uv) installed
 
 ### Setup

--- a/netbox_agent_compliance/mcp.py
+++ b/netbox_agent_compliance/mcp.py
@@ -75,15 +75,16 @@ def create_mcp_server(
             "netbox_get_objects",  # List objects with filters
             "netbox_get_object_by_id",  # Get specific object details
             "netbox_get_changelogs",  # View change history
+            "netbox_search_objects",  # Search objects (v1.0.0+)
         ]
 
     # Expand user directory and verify the MCP server directory exists
     mcp_dir = os.path.expanduser(mcp_dir)
-    server_path = os.path.join(mcp_dir, "server.py")
-    if not os.path.exists(server_path):
+    pyproject_path = os.path.join(mcp_dir, "pyproject.toml")
+    if not os.path.exists(pyproject_path):
         raise FileNotFoundError(
-            f"NetBox MCP server not found at {server_path}. "
-            f"Please ensure the server is installed at {mcp_dir}"
+            f"NetBox MCP server not found at {mcp_dir}. "
+            f"Please ensure the netbox-mcp-server is installed at {mcp_dir}"
         )
 
     # Create the MCP server configuration
@@ -97,7 +98,7 @@ def create_mcp_server(
         params={
             # Command to spawn the MCP server subprocess
             "command": "uv",
-            "args": ["--directory", mcp_dir, "run", "server.py"],
+            "args": ["--directory", mcp_dir, "run", "netbox-mcp-server"],
             # Environment variables for the subprocess
             "env": {
                 "NETBOX_URL": netbox_url,


### PR DESCRIPTION
## Summary

- Update server invocation from `server.py` to `netbox-mcp-server` (breaking change in v1.0.0)
- Update path check from `server.py` to `pyproject.toml`
- Add `netbox_search_objects` to allowed tools (new tool in v1.0.0)
- Update README to specify v1.0.0+ requirement

## Test plan

- [x] Created local venv and installed package
- [x] Verified MCP server has `pyproject.toml` but no `server.py`
- [x] Tested agent startup - MCP server spawns correctly with new command

🤖 Generated with [Claude Code](https://claude.ai/code)